### PR TITLE
Return the source map as a JSON object rather than a string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ class ProcessHtml {
     };
     if (sourceMapGenerator) {
       sourceMapGenerator.setSourceContent(this.currentFilePath, this.content);
-      retVal.sourceMap = sourceMapGenerator.toString(); // Actually returns JSON
+      retVal.sourceMap = sourceMapGenerator.toJSON();
     }
     return retVal;
   }


### PR DESCRIPTION
Babel crashes when the source map is provided as a string. Make sure we provide it as a JSON object.