### PR TITLE
add a test suite

### DIFF
--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loader can process basic input 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.toBody('<div></div>');
+"
+`;
+
+exports[`loader can process without options 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.toBody('<div></div>');
+"
+`;
+
+exports[`loader domModule adds to body if no dom-module 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.toBody('<span></span>');
+"
+`;
+
+exports[`loader domModule ignores invalid HTML 1`] = `""`;
+
+exports[`loader domModule removes link tags 1`] = `
+"
+import 'src/test.html';
+
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+"
+`;
+
+exports[`loader domModule removes script tags without a protocol 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+
+import 'src/foo.js';
+"
+`;
+
+exports[`loader domModule removes script tags without a source 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+
+var x = 1;
+"
+`;
+
+exports[`loader domModule transforms dom-modules 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"><div></div></dom-module>');
+"
+`;
+
+exports[`loader links ignoreLinks option 1`] = `
+"
+import 'src/foofoo.html';
+"
+`;
+
+exports[`loader links ignoreLinksFromPartialMatches option 1`] = `""`;
+
+exports[`loader links ignorePathReWrite option 1`] = `
+"
+import 'foo.html';
+
+import 'foofoo.html';
+"
+`;
+
+exports[`loader links ignores links with invalid href 1`] = `""`;
+
+exports[`loader links transforms links 1`] = `
+"
+import 'src/foo.html';
+"
+`;
+
+exports[`loader scripts maintains external scripts 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+RegisterHtmlTemplate.toBody('<script src=\\"http://example.com/test.js\\"></script>');
+"
+`;
+
+exports[`loader scripts maintains inline scripts 1`] = `
+"
+var x = 5;
+"
+`;
+
+exports[`loader scripts transforms scripts with a source into imports 1`] = `
+"
+import 'src/foo.js';
+"
+`;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,184 @@
+/* eslint no-undefined: "off", no-useless-escape: "off" */
+
+import loader from '../src';
+
+const normalisePaths = result => result.replace('src\\\\', 'src/');
+
+describe('loader', () => {
+  let opts;
+
+  beforeEach(() => {
+    opts = {
+      callback: jest.fn(),
+      resourcePath: 'src/test.html',
+      query: {},
+    };
+  });
+
+  test('can process basic input', () => {
+    loader.call(opts, '<div></div>');
+
+    const [call] = opts.callback.mock.calls;
+
+    expect(call[0]).toBe(null);
+    expect(normalisePaths(call[1])).toMatchSnapshot();
+    expect(call[2]).toBe(undefined);
+  });
+
+  test('can process without options', () => {
+    opts.query = null;
+
+    loader.call(opts, '<div></div>');
+
+    const [call] = opts.callback.mock.calls;
+
+    expect(call[0]).toBe(null);
+    expect(normalisePaths(call[1])).toMatchSnapshot();
+    expect(call[2]).toBe(undefined);
+  });
+
+  describe('links', () => {
+    test('transforms links', () => {
+      loader.call(opts, '<link rel="import" href="foo.html">');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('ignores links with invalid href', () => {
+      loader.call(opts, '<link rel="import" href="">');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('ignoreLinks option', () => {
+      opts.query.ignoreLinks = ['foo.html'];
+
+      loader.call(opts, '<link rel="import" href="foo.html">' +
+        '<link rel="import" href="foofoo.html">');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('ignoreLinksFromPartialMatches option', () => {
+      opts.query.ignoreLinksFromPartialMatches = ['foo.html'];
+
+      loader.call(opts, '<link rel="import" href="foo.html">' +
+        '<link rel="import" href="foofoo.html">');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('ignorePathReWrite option', () => {
+      opts.query.ignorePathReWrite = ['foo.html'];
+
+      loader.call(opts, '<link rel="import" href="foo.html">' +
+        '<link rel="import" href="foofoo.html">');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+  });
+
+  describe('domModule', () => {
+    test('transforms dom-modules', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<div></div></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('ignores invalid HTML', () => {
+      loader.call(opts, '</td>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('removes script tags without a source', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<script>var x = 1;</script></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).not.toBe(undefined);
+    });
+
+    test('removes script tags without a protocol', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<script src="foo.js"></script></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('removes link tags', () => {
+      loader.call(opts, '<link rel="import" href="test.html">' +
+        '<dom-module id="x-foo"></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('adds to body if no dom-module', () => {
+      loader.call(opts, '<span></span>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+  });
+
+  describe('scripts', () => {
+    test('transforms scripts with a source into imports', () => {
+      loader.call(opts, '<script src="foo.js"></script>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('maintains external scripts', () => {
+      loader.call(opts, '<script src="http://example.com/test.js"></script>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe(undefined);
+    });
+
+    test('maintains inline scripts', () => {
+      loader.call(opts, '<script>var x = 5;</script>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).not.toBe(undefined);
+    });
+  });
+});

--- a/test/register-html-template.test.js
+++ b/test/register-html-template.test.js
@@ -1,0 +1,34 @@
+/* eslint-env browser */
+
+import RegisterHtmlTemplate from '../register-html-template';
+
+describe('RegisterHtmlTemplate', () => {
+  describe('register', () => {
+    // doesn't pass until we can spy on importNode
+    // or define a custom element to track registrations in jsdom
+    test.skip('imports node', () => {
+      jest.spyOn(document, 'importNode');
+
+      RegisterHtmlTemplate.register('<dom-module id="x-foo"></dom-module>');
+      expect(document.importNode.calls[0][0].innerHTML)
+        .toBe('<dom-module id="x-foo"></dom-module>');
+    });
+  });
+
+  describe('toBody', () => {
+    test('ignores empty values', () => {
+      RegisterHtmlTemplate.toBody('    ');
+      expect(document.body.innerHTML).toBe('');
+    });
+
+    test('ignores invalid html', () => {
+      RegisterHtmlTemplate.toBody('</span>');
+      expect(document.body.innerHTML).toBe('');
+    });
+
+    test('prepends elements', () => {
+      RegisterHtmlTemplate.toBody('<div id="test"></div>');
+      expect(document.body.innerHTML).toBe('<div id="test"></div>');
+    });
+  });
+});


### PR DESCRIPTION
here's some tests for #7.

i couldn't test `RegisterHtmlTemplate.register` (there are two branches to test in there) because jsdom's `importNode` apparently can't be mocked/spied upon.

also if the inline templates and expectations are nasty, i could throw them all into separate files maybe?

a couple of tests also probably do overlap too due to each internal method always running.

p.s. I used jest because it was already in there...