### PR TITLE
Ensure windows paths get escaped

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ import sourceMap from 'source-map';
 const domPred = predicates.AND(predicates.hasTagName('dom-module'));
 const linkPred = predicates.AND(predicates.hasTagName('link'));
 const scriptsPred = predicates.AND(predicates.hasTagName('script'));
-const windowsPathRegExp = new RegExp('\\\\', 'g');
 
 class ProcessHtml {
   constructor(content, loader) {
@@ -61,7 +60,7 @@ class ProcessHtml {
         const ignoredFromPartial = ignoreLinksFromPartialMatches.filter(partial => href.indexOf(partial) >= 0);
 
         if (ignoreLinks.indexOf(href) < 0 && ignoredFromPartial.length === 0) {
-          source += `\nimport '${path.replace(windowsPathRegExp, '\\\\')}';\n`;
+          source += `\nimport '${path.replace(/\\/g, '\\\\')}';\n`;
           lineCount += 2;
         }
       }
@@ -154,7 +153,7 @@ RegisterHtmlTemplate.toBody('${minimized.replace(/'/g, "\\'")}');
         const parseSrc = url.parse(src);
         if (!parseSrc.protocol || !parseSrc.slashes) {
           const path = osPath.join(osPath.dirname(this.currentFilePath), src);
-          source += `\nimport '${path.replace(windowsPathRegExp, '\\\\')}';\n`;
+          source += `\nimport '${path.replace(/\\/g, '\\\\')}';\n`;
           lineOffset += 2;
         }
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import sourceMap from 'source-map';
 const domPred = predicates.AND(predicates.hasTagName('dom-module'));
 const linkPred = predicates.AND(predicates.hasTagName('link'));
 const scriptsPred = predicates.AND(predicates.hasTagName('script'));
+const windowsPathRegExp = new RegExp('\\\\', 'g');
 
 class ProcessHtml {
   constructor(content, loader) {
@@ -60,7 +61,7 @@ class ProcessHtml {
         const ignoredFromPartial = ignoreLinksFromPartialMatches.filter(partial => href.indexOf(partial) >= 0);
 
         if (ignoreLinks.indexOf(href) < 0 && ignoredFromPartial.length === 0) {
-          source += `\nimport '${path}';\n`;
+          source += `\nimport '${path.replace(windowsPathRegExp, '\\\\')}';\n`;
           lineCount += 2;
         }
       }
@@ -153,7 +154,7 @@ RegisterHtmlTemplate.toBody('${minimized.replace(/'/g, "\\'")}');
         const parseSrc = url.parse(src);
         if (!parseSrc.protocol || !parseSrc.slashes) {
           const path = osPath.join(osPath.dirname(this.currentFilePath), src);
-          source += `\nimport '${path}';\n`;
+          source += `\nimport '${path.replace(windowsPathRegExp, '\\\\')}';\n`;
           lineOffset += 2;
         }
       } else {


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Fixes #28 

Adds path.replace with a regular expression to ensure that paths get correctly escaped.

