### PR TITLE
Use webpack builtins for config options that match paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,56 +7,77 @@
 The loader allows you to write mixed HTML, CSS and JavaScript Polymer elements and
 still use the full webpack ecosystem including module bundling and code splitting.
 
-
 <img width="1024" alt="" src="https://user-images.githubusercontent.com/1066253/28131928-3b257288-66f0-11e7-8295-cb968cefb040.png">
 
 The loader transforms your components:
 
- * `<link rel="import" href="./my-other-element.html">` -> `import './my-other-element.html';`
- * `<dom-module>` becomes a string which is registered at runtime
- * `<script src="./other-script.js"></script>` -> `import './other-script.js';`
- * `<script>/* contents */</script>` -> `/* contents */`
+ Before                                               | After
+------------------------------------------------------|----------------------------------------------------------------------
+ `<link rel="import" href="./my-other-element.html">` | `import '/path/to/my-other-element.html';`
+ `<dom-module id="my-element"> ...`                   | `RegisterHtmlTemplate.register('<dom-module id="my-element"> ...');`
+ `<script src="./other-script.js"></script>`          | `import '/path/to/other-script.js';`
+ `<script>/* contents */</script>`                    | `/* contents */`
 
 ## Configuring the Loader
 
 ```javascript
 {
-  test: /\.html$/,  
-  include: Array (optional),
-  exclude: RegExp (optional),
+  test: /\.html$/,
+  include: Condition(s) (optional),
+  exclude: Condition(s) (optional),
   options: {
-    ignoreLinks: Array (optional),
-    ignoreLinksFromPartialMatches: Array (optional),
-    ignorePathReWrite: Array (optional)
+    ignoreLinks: Condition(s) (optional),
+    ignoreLinksFromPartialMatches: Array<String> (optional),
+    ignorePathReWrite: Condition(s) (optional)
   },
   loader: 'polymer-webpack-loader'
 },
 ```
 
-### include: Array
+### include: Condition(s)
 
-Directories that contain your web components. This will allow you to control where the loader can access files to process. WARNING: If this property exists the loader will only process files that have their parent directory listed. So if you have `<link>` in your components to other directories they MUST be included in this Array.
+See [Rule.include] and [Condition] in the webpack documentation. Paths
+matching this option will be processed by polymer-webpack-loader.  WARNING: If
+this property exists the loader will only process files matching the given
+conditions. If your component has a `<link>` pointing to a component e.g. in
+another directory, the `include` condition(s) MUST also match that directory.
 
-### exclude: RegExp
+[Rule.include]: https://webpack.js.org/configuration/module/#rule-include
+[Condition]: https://webpack.js.org/configuration/module/#condition
 
-A regular expression for files that the loader should exclude. NOTE: Files imported through a `<link>` will not be excluded by this property. See Options.ignoreLinks.
+### exclude: Condition(s)
+
+See [Rule.exclude] and [Condition] in the webpack documentation. Paths
+matching this option will be excluded from processing by
+polymer-webpack-loader. NOTE: Files imported through a `<link>` will not be
+excluded by this property. See `Options.ignoreLinks`.
+
+[Rule.exclude]: https://webpack.js.org/configuration/module/#rule-exclude
 
 ### Options
 
-#### ignoreLinks: Array
+#### ignoreLinks: Condition(s)
 
-An array of paths to be ignored when dynamically imported. When the component loader comes across a `<link>` in your components it dynamically imports the value of href attribute.  
+`<link>`s pointing to paths matching these conditions (see [Condition] in the
+webpack documentation) will not be transformed into `import`s.
 
 #### ignoreLinksFromPartialMatches: Array
 
-An array of paths to be ignored when dynamically imported based on match of string anywhere within the path. When the component loader comes across a `<link>` in your components it dynamically imports the value of href attribute.  
+`<link>`s pointing to paths that match or contain strings in this array will
+not be transformed into `import`s.
 
-#### ignorePathReWrite: Array
+#### ignorePathReWrite: Condition(s)
 
-Paths the loader will respect as is. In order to properly import certain paths, checks are made to ensure the path is picked up correctly by Webpack. Paths matching a value in the Array will be imported as is, you may have aliases or just want the loader to respect the path.
+`<link>` paths matching these conditions (see [Condition] in the webpack
+documentation) will not be changed when transformed into `import`s. This can
+be useful for respecting aliases, loader syntax (e.g.
+`markup-inline-loader!./my-element.html`), or module paths.
 
 ### Use with Babel (or other JS transpilers)
-If you'd like to transpile the contents of your element's `<script>` block you can [chain an additional loader](https://webpack.js.org/configuration/module/#rule-use).
+
+If you'd like to transpile the contents of your element's `<script>` block you
+can [chain an additional
+loader](https://webpack.js.org/configuration/module/#rule-use).
 
 ```js
 module: {
@@ -86,9 +107,10 @@ module: {
 ```
 
 ### Use of HtmlWebpackPlugin
-Depending on how you configure the HtmlWebpackPlugin you may encounter conflicts with the polymer-webpack-loader. 
+Depending on how you configure the HtmlWebpackPlugin you may encounter
+conflicts with the polymer-webpack-loader.
 
-Example: 
+Example:
 
 ```javascript
 {
@@ -99,11 +121,16 @@ Example:
   ],
 },
 {
-  test: /\.html$/,  
+  test: /\.html$/,
   loader: 'polymer-webpack-loader'
 }
 ```
-This would expose your index.html file to the polymer-webpack-loader based on the process used by the html-loader. In this case you would need to exclude your html file from the polymer-webpack-loader or look for other ways to avoid this conflict. See: [html-webpack-plugin template options](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md)
+
+This would expose your `index.html` file to the polymer-webpack-loader based
+on the process used by the html-loader. In this case you would need to exclude
+your HTML file from the polymer-webpack-loader or look for other ways to avoid
+this conflict. See: [html-webpack-plugin template
+options](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md)
 
 <h2 align="center">Maintainers</h2>
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -3,21 +3,21 @@
 exports[`loader can process basic input 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<div></div>');
+RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
 
 exports[`loader can process without options 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<div></div>');
+RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
 
 exports[`loader domModule adds to body if no dom-module 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<span></span>');
+RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 "
 `;
 
@@ -25,26 +25,26 @@ exports[`loader domModule ignores invalid HTML 1`] = `""`;
 
 exports[`loader domModule removes link tags 1`] = `
 "
-import 'src/test.html';
+import \\"src/test.html\\";
 
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 "
 `;
 
 exports[`loader domModule removes script tags without a protocol 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
-import 'src/foo.js';
+import \\"src/foo.js\\";
 "
 `;
 
 exports[`loader domModule removes script tags without a source 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 var x = 1;
 "
@@ -53,13 +53,13 @@ var x = 1;
 exports[`loader domModule transforms dom-modules 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"><div></div></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
 "
 `;
 
 exports[`loader links ignoreLinks option 1`] = `
 "
-import 'src/foofoo.html';
+import \\"src/foofoo.html\\";
 "
 `;
 
@@ -67,9 +67,9 @@ exports[`loader links ignoreLinksFromPartialMatches option 1`] = `""`;
 
 exports[`loader links ignorePathReWrite option 1`] = `
 "
-import 'foo.html';
+import \\"foo.html\\";
 
-import 'foofoo.html';
+import \\"src/foofoo.html\\";
 "
 `;
 
@@ -77,14 +77,14 @@ exports[`loader links ignores links with invalid href 1`] = `""`;
 
 exports[`loader links transforms links 1`] = `
 "
-import 'src/foo.html';
+import \\"src/foo.html\\";
 "
 `;
 
 exports[`loader scripts maintains external scripts 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<script src=\\"http://example.com/test.js\\"></script>');
+RegisterHtmlTemplate.toBody(\\"<script src=\\\\\\"http://example.com/test.js\\\\\\"></script>\\");
 "
 `;
 
@@ -96,6 +96,6 @@ var x = 5;
 
 exports[`loader scripts transforms scripts with a source into imports 1`] = `
 "
-import 'src/foo.js';
+import \\"src/foo.js\\";
 "
 `;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -57,10 +57,17 @@ describe('loader', () => {
     });
 
     test('ignoreLinks option', () => {
-      opts.query.ignoreLinks = ['foo.html'];
+      opts.query.ignoreLinks = [
+        'foo.html',
+        '/bar',
+        /node_modules/,
+      ];
 
       loader.call(opts, '<link rel="import" href="foo.html">' +
-        '<link rel="import" href="foofoo.html">');
+        '<link rel="import" href="foofoo.html">' +
+        '<link rel="import" href="/bar/foo.html">' +
+        '<link rel="import" href="../../node_modules/some-module/some-element.html">',
+      );
 
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);


### PR DESCRIPTION
For consistency, polymer-webpack-loader should let users specify its `ignoreLinks` et al options using the same condition syntax as they use to configure loader rules, rather than a different and more limited string-matching approach.

This PR achieves that by using webpack's `RuleSet.normalizeCondition`, which takes a [Condition] object (String, RegExp, function, array, etc.) just like `rules` in a webpack configuration, and returns a function that tests a given string.

This is a breaking change in two ways:

 1. Whereas previously `ignoreLinks` took an array of strings that would be matched exactly against `<link>` `href`s, now given strings will match exactly *or* as a directory prefix. For example, `ignoreLinks: ['foo.html', '/bar']` will now match both `foo.html` and `/bar/baz.html`).

 2. Whereas previous `ignorePathReWrite` took an array of strings that would be matched partially (i.e. as substrings) against `<link>` `href`s, given strings will now match in the same manner as above.

The behavior of `ignoreLinksFromPartialMatches` is unchanged. I recommend, however, that `ignoreLinksFromPartialMatches` be deprectated, since it is now obsoleted by the more flexible `ignoreLinks` option.

[Condition]: https://webpack.js.org/configuration/module/#condition

### Other changes

  - Use [`loaderUtils.stringifyRequest`] instead of `String.prototype.replace` to escape paths in generated `import`s.
  - Use `JSON.stringify` instead of `String.prototype.replace` to escape HTML in generated code.

[`loaderUtils.stringifyRequest`]: https://github.com/webpack/loader-utils#stringifyrequest

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
