### PR TITLE
updates the html string to use JSON.stringify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ class ProcessHtml {
         return {
           source: `
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('${minimized.replace(/'/g, "\\'")}');
+RegisterHtmlTemplate.register(${JSON.stringify(minimized)});
 `,
           lineCount: 3,
         };
@@ -120,7 +120,7 @@ RegisterHtmlTemplate.register('${minimized.replace(/'/g, "\\'")}');
       return {
         source: `
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('${minimized.replace(/'/g, "\\'")}');
+RegisterHtmlTemplate.toBody(${JSON.stringify(minimized)});
 `,
         lineCount: 3,
       };

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -3,21 +3,21 @@
 exports[`loader can process basic input 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<div></div>');
+RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
 
 exports[`loader can process without options 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<div></div>');
+RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
 
 exports[`loader domModule adds to body if no dom-module 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<span></span>');
+RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 "
 `;
 
@@ -28,14 +28,14 @@ exports[`loader domModule removes link tags 1`] = `
 import './test.html';
 
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 "
 `;
 
 exports[`loader domModule removes script tags without a protocol 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 import './foo.js';
 "
@@ -44,7 +44,7 @@ import './foo.js';
 exports[`loader domModule removes script tags without a source 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 var x = 1;
 "
@@ -53,7 +53,7 @@ var x = 1;
 exports[`loader domModule transforms dom-modules 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.register('<dom-module id=\\"x-foo\\"><div></div></dom-module>');
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
 "
 `;
 
@@ -84,7 +84,7 @@ import './foo.html';
 exports[`loader scripts maintains external scripts 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-RegisterHtmlTemplate.toBody('<script src=\\"http://example.com/test.js\\"></script>');
+RegisterHtmlTemplate.toBody(\\"<script src=\\\\\\"http://example.com/test.js\\\\\\"></script>\\");
 "
 `;
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Discovered a few additional special characters that were not being escaped property. Switch to using JSON.stringify to escape the html content.  