### PR TITLE
use require to avoid import hoisting issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@ class ProcessHtml {
     return this.scripts(links.source + doms.source, links.lineCount + doms.lineCount);
   }
   /**
-   * Look for all `<link>` elements and turn them into `import` statements.
+   * Look for all `<link>` elements and turn them into `require` statements.
    * e.g.
    * ```
    * <link rel="import" href="paper-input/paper-input.html">
    * becomes:
-   * import 'paper-input/paper-input.html';
+   * require('paper-input/paper-input.html');
    * ```
    * @return {{source: string, lineCount: number}}
    */
@@ -60,7 +60,7 @@ class ProcessHtml {
         const parseLink = url.parse(href);
         const isExternalLink = parseLink.protocol || parseLink.slashes;
         if (ignoreLinks.indexOf(href) < 0 && ignoredFromPartial.length === 0 && !isExternalLink) {
-          source += `\nimport '${path}';\n`;
+          source += `\nrequire('${path}');\n`;
           lineCount += 2;
         }
       }
@@ -132,12 +132,12 @@ RegisterHtmlTemplate.toBody(${JSON.stringify(minimized)});
   }
   /**
    * Look for all `<script>` elements. If the script has a valid `src` attribute
-   * it will be converted to an `import` statement.
+   * it will be converted to a `require` statement.
    * e.g.
    * ```
    * <script src="foo.js">
    * becomes:
-   * import 'foo';
+   * require('foo');
    * ```
    * Otherwise if it's an inline script block, the content will be serialized
    * and returned as part of the bundle.
@@ -158,7 +158,7 @@ RegisterHtmlTemplate.toBody(${JSON.stringify(minimized)});
         const parseSrc = url.parse(src);
         if (!parseSrc.protocol || !parseSrc.slashes) {
           const path = ProcessHtml.checkPath(src);
-          source += `\nimport '${path}';\n`;
+          source += `\nrequire('${path}');\n`;
           lineOffset += 2;
         }
       } else {

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -25,7 +25,7 @@ exports[`loader domModule ignores invalid HTML 1`] = `""`;
 
 exports[`loader domModule removes link tags 1`] = `
 "
-import './test.html';
+require('./test.html');
 
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
@@ -37,7 +37,7 @@ exports[`loader domModule removes script tags without a protocol 1`] = `
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
-import './foo.js';
+require('./foo.js');
 "
 `;
 
@@ -59,7 +59,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div><
 
 exports[`loader links ignoreLinks option 1`] = `
 "
-import './foofoo.html';
+require('./foofoo.html');
 "
 `;
 
@@ -67,9 +67,9 @@ exports[`loader links ignoreLinksFromPartialMatches option 1`] = `""`;
 
 exports[`loader links ignorePathReWrite option 1`] = `
 "
-import 'foo.html';
+require('foo.html');
 
-import 'foofoo.html';
+require('foofoo.html');
 "
 `;
 
@@ -77,7 +77,7 @@ exports[`loader links ignores links with invalid href 1`] = `""`;
 
 exports[`loader links transforms links 1`] = `
 "
-import './foo.html';
+require('./foo.html');
 "
 `;
 
@@ -96,6 +96,6 @@ var x = 5;
 
 exports[`loader scripts transforms scripts with a source into imports 1`] = `
 "
-import './foo.js';
+require('./foo.js');
 "
 `;


### PR DESCRIPTION
From this:

```
<dom-module id="x-foo">
  <template><h1>Foo</h1></template>
  <script src="./Foo.js"></script>
</dom-module>
```

Currently, we produce something like this:

```
const RegisterHtmlTemplate = require('...');
RegisterHtmlTemplate.register('...');

import './Foo.js';
```

By the current JS spec, imports are hoisted, so our actual execution order (in webpack too) becomes:

```
import './Foo.js';

const RegisterHtmlTemplate = require('...');
RegisterHtmlTemplate.register('...');
```

---

This leads to us registering dom-modules after their associated classes, which is disallowed as per the polymer docs.

The quick solution to this is to use `require(...)` instead, as it will not be hoisted.

However, in future, we probably should find a better way to maintain ordering while using imports.

cc @ChadKillingsworth 