### PR TITLE
Process css

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ be useful for respecting aliases, loader syntax (e.g.
 
 If set to true the loader will rewrite `<link import="css" href="...">` or `<link rel="stylesheet" href="...">` that are inside the dom-module with `<style>require('...')</style>`. This will allow for the file to be processed by loaders that are set up in the webpack config to handle their file type. 
 
-1. Any `<link>` that is inside the dom-module but not in the template will be added to the template in the order the tags appear in the file. 
+1. Any `<link>` that is inside the `<dom-module>` but not in the `<template>` will be added to the `<template>` in the order the tags appear in the file. 
 ```html
   <dom-module>
     <link rel="stylesheet" href="file1.css">

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ class ProcessHtml {
         // line number of the script tag itself. And for the first line, offset the start
         // column to account for the <script> tag itself.
         const currentScriptLineOffset = scriptNode.childNodes[0].__location.line - 1; // eslint-disable-line no-underscore-dangle
-        const firstLineCharOffset = scriptNode.childNodes[0].__location.col; // eslint-disable-line no-underscore-dangle
+        const firstLineCharOffset = scriptNode.childNodes[0].__location.col - 1; // eslint-disable-line no-underscore-dangle
         tokens.forEach((token) => {
           if (!token.loc) {
             return;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ class ProcessHtml {
     this.options = loaderUtils.getOptions(loader) || {};
     this.currentFilePath = loader.resourcePath;
   }
+
   /**
    * Process `<link>` tags, `<dom-module>` elements, and any `<script>`'s.
    * Return transformed content as a bundle for webpack.
@@ -78,10 +79,11 @@ class ProcessHtml {
       sourceMap: scriptsSource.sourceMap,
     };
   }
+
   /**
    * Process an array of ```<link>``` to determine if each needs to be ```require``` statement or ignored.
    *
-   * @param {Array<HtmlElements>} links
+   * @param {Array<HTMLElement>} links
    * @return {string}
    */
   links(links) {
@@ -113,7 +115,7 @@ class ProcessHtml {
    * Process an array of ```<script>``` to determine if each needs to be a ```require``` statement
    * or have its contents written to the webpack module
    *
-   * @param {Array[HtmlElements]} scripts
+   * @param {Array<HTMLElement>} scripts
    * @param {number} initialLineCount
    * @return {{source: string, sourceMap: (Object|undefined)}}
    */
@@ -181,7 +183,7 @@ class ProcessHtml {
   /**
    * Generates required runtime source for the HtmlElements that need to be registered
    * either in the body or as document fragments on the document.
-   * @param {Array<HtmlElements>} nodes
+   * @param {Array<HTMLElement>} nodes
    * @param {RuntimeRegistrationType} type
    * @return {string}
    */
@@ -219,12 +221,12 @@ RegisterHtmlTemplate.${registrationMethod}(${JSON.stringify(minimized)});
    * <link href="http://www.example.com/main.html">
    * returns: true
    * ```
-   * @param {HtmlElement} node
-   * @param {HtmlElement} pathType src or href
+   * @param {HTMLElement} node
+   * @param {string} attributeName src or href
    * @return {boolean}
    */
-  static isExternalPath(node, pathType) {
-    const path = getAttribute(node, pathType) || '';
+  static isExternalPath(node, attributeName) {
+    const path = getAttribute(node, attributeName) || '';
     const parseLink = url.parse(path);
     return parseLink.protocol || parseLink.slashes;
   }
@@ -238,7 +240,7 @@ RegisterHtmlTemplate.${registrationMethod}(${JSON.stringify(minimized)});
    * <link rel="stylesheet" href="...">
    * returns: true
    * ```
-   * @param {HtmlElement} node
+   * @param {HTMLElement} node
    * @return {boolean}
    */
   static isCSSLink(node) {

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -3,6 +3,7 @@
 exports[`loader can process basic input 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
@@ -10,6 +11,7 @@ RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 exports[`loader can process without options 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
 `;
@@ -17,6 +19,7 @@ RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 exports[`loader domModule adds to body if no dom-module 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 "
 `;
@@ -28,22 +31,49 @@ exports[`loader domModule removes link tags 1`] = `
 require('./test.html');
 
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
+"
+`;
+
+exports[`loader domModule keeps css link tags with import 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\\\\\"import\\\\\\" type=\\\\\\"css\\\\\\" href=\\\\\\"test.css\\\\\\"></dom-module>\\");
+"
+`;
+
+exports[`loader domModule keeps css link tags with rel stylesheet 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"test.css\\\\\\"></dom-module>\\");
 "
 `;
 
 exports[`loader domModule removes script tags without a protocol 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 require('./foo.js');
 "
 `;
 
+exports[`loader domModule ignore script tags in a template 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><script>var x = 1;</script></template></dom-module>\\");
+"
+`;
+
 exports[`loader domModule removes script tags without a source 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 var x = 1;
@@ -53,7 +83,26 @@ var x = 1;
 exports[`loader domModule transforms dom-modules 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
+"
+`;
+
+exports[`loader domModule transforms multiple dom-modules 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo-foo\\\\\\"><div></div></dom-module>\\");
+"
+`;
+
+exports[`loader domModule ignore non root level dom-modules 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.toBody(\\"<template><dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module></template>\\");
 "
 `;
 
@@ -84,6 +133,7 @@ require('./foo.html');
 exports[`loader scripts maintains external scripts 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
 RegisterHtmlTemplate.toBody(\\"<script src=\\\\\\"http://example.com/test.js\\\\\\"></script>\\");
 "
 `;

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -24,17 +24,23 @@ RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 "
 `;
 
-exports[`loader domModule ignores invalid HTML 1`] = `""`;
-
-exports[`loader domModule removes link tags 1`] = `
+exports[`loader domModule ignore non root level dom-modules 1`] = `
 "
-require('./test.html');
-
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
 
-RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
+RegisterHtmlTemplate.toBody(\\"<template><dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module></template>\\");
 "
 `;
+
+exports[`loader domModule ignore script tags in a template 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><script>var x = 1;</script></template></dom-module>\\");
+"
+`;
+
+exports[`loader domModule ignores invalid HTML 1`] = `""`;
 
 exports[`loader domModule keeps css link tags with import 1`] = `
 "
@@ -52,6 +58,16 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\
 "
 `;
 
+exports[`loader domModule removes link tags 1`] = `
+"
+require('./test.html');
+
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
+"
+`;
+
 exports[`loader domModule removes script tags without a protocol 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
@@ -59,14 +75,6 @@ const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-templ
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
 require('./foo.js');
-"
-`;
-
-exports[`loader domModule ignore script tags in a template 1`] = `
-"
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-
-RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><script>var x = 1;</script></template></dom-module>\\");
 "
 `;
 
@@ -95,14 +103,6 @@ const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-templ
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo-foo\\\\\\"><div></div></dom-module>\\");
-"
-`;
-
-exports[`loader domModule ignore non root level dom-modules 1`] = `
-"
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
-
-RegisterHtmlTemplate.toBody(\\"<template><dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module></template>\\");
 "
 `;
 
@@ -141,6 +141,11 @@ RegisterHtmlTemplate.toBody(\\"<script src=\\\\\\"http://example.com/test.js\\\\
 exports[`loader scripts maintains inline scripts 1`] = `
 "
 var x = 5;
+        function foobar(arg) {
+          var y = 6;
+        
+        }
+      
 "
 `;
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -21,7 +21,7 @@ describe('loader', () => {
     const [call] = opts.callback.mock.calls;
     expect(call[0]).toBe(null);
     expect(normalisePaths(call[1])).toMatchSnapshot();
-    expect(call[2]).toBe('');
+    expect(call[2]).toBe(undefined);
   });
 
   test('can process without options', () => {
@@ -33,7 +33,7 @@ describe('loader', () => {
 
     expect(call[0]).toBe(null);
     expect(normalisePaths(call[1])).toMatchSnapshot();
-    expect(call[2]).toBe('');
+    expect(call[2]).toBe(undefined);
   });
 
   describe('links', () => {
@@ -43,7 +43,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignores links with invalid href', () => {
@@ -52,7 +52,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignoreLinks option', () => {
@@ -64,7 +64,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignoreLinksFromPartialMatches option', () => {
@@ -76,7 +76,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignorePathReWrite option', () => {
@@ -88,7 +88,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
   });
 
@@ -100,7 +100,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('transforms multiple dom-modules', () => {
@@ -111,7 +111,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignore non root level dom-modules', () => {
@@ -121,7 +121,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignores invalid HTML', () => {
@@ -130,7 +130,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('ignore script tags in a template', () => {
@@ -140,7 +140,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('removes script tags without a source', () => {
@@ -150,7 +150,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).not.toBe(undefined);
     });
 
     test('removes script tags without a protocol', () => {
@@ -160,7 +160,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('removes link tags', () => {
@@ -170,7 +170,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('keeps css link tags with import', () => {
@@ -180,7 +180,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('keeps css link tags with rel stylesheet', () => {
@@ -190,7 +190,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('adds to body if no dom-module', () => {
@@ -199,7 +199,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
   });
 
@@ -210,7 +210,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('maintains external scripts', () => {
@@ -219,7 +219,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe('');
+      expect(call[2]).toBe(undefined);
     });
 
     test('maintains inline scripts', () => {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -19,10 +19,9 @@ describe('loader', () => {
     loader.call(opts, '<div></div>');
 
     const [call] = opts.callback.mock.calls;
-
     expect(call[0]).toBe(null);
     expect(normalisePaths(call[1])).toMatchSnapshot();
-    expect(call[2]).toBe(undefined);
+    expect(call[2]).toBe('');
   });
 
   test('can process without options', () => {
@@ -34,7 +33,7 @@ describe('loader', () => {
 
     expect(call[0]).toBe(null);
     expect(normalisePaths(call[1])).toMatchSnapshot();
-    expect(call[2]).toBe(undefined);
+    expect(call[2]).toBe('');
   });
 
   describe('links', () => {
@@ -44,7 +43,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('ignores links with invalid href', () => {
@@ -53,7 +52,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('ignoreLinks option', () => {
@@ -65,7 +64,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('ignoreLinksFromPartialMatches option', () => {
@@ -77,7 +76,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('ignorePathReWrite option', () => {
@@ -89,7 +88,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
   });
 
@@ -101,7 +100,28 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
+    });
+
+    test('transforms multiple dom-modules', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<div></div></dom-module><dom-module id="x-foo-foo">' +
+        '<div></div></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe('');
+    });
+
+    test('ignore non root level dom-modules', () => {
+      loader.call(opts, '<template><dom-module id="x-foo">' +
+        '<div></div></dom-module></template>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe('');
     });
 
     test('ignores invalid HTML', () => {
@@ -110,7 +130,17 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
+    });
+
+    test('ignore script tags in a template', () => {
+      loader.call(opts, '<dom-module id="x-foo"><template>' +
+        '<script>var x = 1;</script></template></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe('');
     });
 
     test('removes script tags without a source', () => {
@@ -120,7 +150,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).not.toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('removes script tags without a protocol', () => {
@@ -130,7 +160,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('removes link tags', () => {
@@ -140,7 +170,27 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
+    });
+
+    test('keeps css link tags with import', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<link rel="import" type="css" href="test.css"></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe('');
+    });
+
+    test('keeps css link tags with rel stylesheet', () => {
+      loader.call(opts, '<dom-module id="x-foo">' +
+        '<link rel="stylesheet" href="test.css"></dom-module>');
+
+      const [call] = opts.callback.mock.calls;
+      expect(call[0]).toBe(null);
+      expect(normalisePaths(call[1])).toMatchSnapshot();
+      expect(call[2]).toBe('');
     });
 
     test('adds to body if no dom-module', () => {
@@ -149,7 +199,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
   });
 
@@ -160,7 +210,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('maintains external scripts', () => {
@@ -169,7 +219,7 @@ describe('loader', () => {
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);
       expect(normalisePaths(call[1])).toMatchSnapshot();
-      expect(call[2]).toBe(undefined);
+      expect(call[2]).toBe('');
     });
 
     test('maintains inline scripts', () => {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -241,7 +241,12 @@ describe('loader', () => {
     });
 
     test('maintains inline scripts', () => {
-      loader.call(opts, '<script>var x = 5;</script>');
+      loader.call(opts, `<script>var x = 5;
+        function foobar(arg) {
+          var y = 6;
+        
+        }
+      </script>`);
 
       const [call] = opts.callback.mock.calls;
       expect(call[0]).toBe(null);


### PR DESCRIPTION
This pr adds the ability for the loader to rewrite relative path stylesheet `<link>` that are inside the `<dom-module>` to `require` statements. This allows the files to be processed by loaders that are in the webpack config for the file type.

Notes: 
1. This functionality only works with the option `processStyleLinks` set to `true`.
2. The appropriate loader for the file type must be in the webpack config.


<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
