### PR TITLE
Don't transpile all node_modules

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -40,7 +40,9 @@ module.exports = {
       {
         // If you see a file that ends in .js, just send it to the babel-loader.
         test: /\.js$/,
-        use: 'babel-loader'
+        use: 'babel-loader',
+        // node_modules can be excluded except for polymer-webpack-loader
+        exclude: /node_modules\/(?!polymer-webpack-loader\/).*/
       }
     ]
   },

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -40,9 +40,9 @@ module.exports = {
       {
         // If you see a file that ends in .js, just send it to the babel-loader.
         test: /\.js$/,
-        use: 'babel-loader',
-        // node_modules can be excluded except for polymer-webpack-loader
-        exclude: /node_modules\/(?!polymer-webpack-loader\/).*/
+        use: 'babel-loader'
+        // Optionally exclude node_modules from transpilation except for polymer-webpack-loader:
+        // exclude: /node_modules\/(?!polymer-webpack-loader\/).*/
       }
     ]
   },


### PR DESCRIPTION
This has a negative impact on the build performance. This will become more apparent in bigger code bases. Only transpiling polymer-webpack-loader is a much better idea.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
