### PR TITLE
Use absolute path for register-html-template require

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-webpack": "^1.2.5",
     "eslint-plugin-import": "^2.7.0",
     "jest": "^20.0.4",
+    "jest-serializer-path": "^0.1.3",
     "lint-staged": "^4.0.1",
     "nsp": "^2.6.3",
     "pre-commit": "^1.2.2",
@@ -77,6 +78,11 @@
     "*.js": [
       "eslint --fix",
       "git add"
+    ]
+  },
+  "jest": {
+    "snapshotSerializers": [
+      "jest-serializer-path"
     ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import { format } from 'util';
 import url from 'url';
 import {
   append,
@@ -34,6 +35,13 @@ const htmlLoaderDefaultOptions = {
     inline: ['none'],
   },
 };
+
+const FMT_CSS_IMPORT_URL = '@import url(%s);';
+
+const REGISTER_HTML_TEMPLATE = format(
+  'const RegisterHtmlTemplate = require(%j);',
+  require.resolve('../register-html-template'),
+);
 
 const STYLE_ID_PREFIX = '__POLYMER_WEBPACK_LOADER_STYLE_';
 const STYLE_ID_EXPR = new RegExp(`/\\* (${STYLE_ID_PREFIX}\\d+__) \\*/`, 'g');
@@ -140,7 +148,7 @@ class ProcessHtml {
 
     let source = this.links(linksArray);
     if (toBodyArray.length > 0 || domModuleArray.length > 0) {
-      source += '\nconst RegisterHtmlTemplate = require(\'polymer-webpack-loader/register-html-template\');\n';
+      source = `${source}\n${REGISTER_HTML_TEMPLATE}\n`;
     }
 
     // After styles are processed, replace the special comments with the rewritten
@@ -408,7 +416,9 @@ class ProcessHtml {
     const newStyleElements = [];
     externalStyleSheets.forEach((linkElement) => {
       const newStyleElement = constructors.element('style');
-      setTextContent(newStyleElement, `@import url(${JSON.stringify(getAttribute(linkElement, 'href'))});`);
+      setTextContent(newStyleElement,
+        format(FMT_CSS_IMPORT_URL, getAttribute(linkElement, 'href')));
+
       let domModule = linkElement;
       for (; domModule && domModule.tagName !== 'dom-module'; domModule = domModule.parentNode);
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`loader can process basic input 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
@@ -10,7 +10,7 @@ RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 
 exports[`loader can process without options 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 "
@@ -18,7 +18,7 @@ RegisterHtmlTemplate.toBody(\\"<div></div>\\");
 
 exports[`loader domModule adds to body if no dom-module 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 "
@@ -26,7 +26,7 @@ RegisterHtmlTemplate.toBody(\\"<span></span>\\");
 
 exports[`loader domModule ignore non root level dom-modules 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<template><dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module></template>\\");
 "
@@ -34,7 +34,7 @@ RegisterHtmlTemplate.toBody(\\"<template><dom-module id=\\\\\\"x-foo\\\\\\"><div
 
 exports[`loader domModule ignore script tags in a template 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><script>var x = 1;</script></template></dom-module>\\");
 "
@@ -42,7 +42,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><s
 
 exports[`loader domModule ignores css link if flag is not set 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"./test.css\\\\\\"></template></dom-module>\\");
 "
@@ -50,7 +50,7 @@ RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"styleshe
 
 exports[`loader domModule ignores css link if flag is not set 2`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"./test.css\\\\\\"></template></dom-module>\\");
 "
@@ -60,7 +60,7 @@ exports[`loader domModule ignores invalid HTML 1`] = `""`;
 
 exports[`loader domModule keeps css link tags with import 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\\\\\"import\\\\\\" type=\\\\\\"css\\\\\\" href=\\\\\\"test.css\\\\\\"></dom-module>\\");
 "
@@ -68,7 +68,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\
 
 exports[`loader domModule keeps css link tags with rel stylesheet 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"test.css\\\\\\"></dom-module>\\");
 "
@@ -76,7 +76,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><link rel=\\
 
 exports[`loader domModule maintains links to stylesheet with an external url file 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"http://example.com/test.css\\\\\\"></template></dom-module>\\");
 "
@@ -84,7 +84,7 @@ RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"styleshe
 
 exports[`loader domModule maintains links to stylesheet with an protocol neutral href 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module><template><link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"//example.com/test.css\\\\\\"></template></dom-module>\\");
 "
@@ -94,7 +94,7 @@ exports[`loader domModule removes link tags 1`] = `
 "
 require('./test.html');
 
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 "
@@ -102,7 +102,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module
 
 exports[`loader domModule removes script tags without a protocol 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
@@ -112,7 +112,7 @@ require('./foo.js');
 
 exports[`loader domModule removes script tags without a source 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"></dom-module>\\");
 
@@ -122,7 +122,7 @@ var x = 1;
 
 exports[`loader domModule rewrites css link tags with rel import 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><style>\\" + require(\\"./test.css\\") + \\"</style></template></dom-module>\\");
 "
@@ -130,7 +130,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><s
 
 exports[`loader domModule rewrites css link tags with rel stylesheet 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><style>\\" + require(\\"./test.css\\") + \\"</style></template></dom-module>\\");
 "
@@ -138,7 +138,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><s
 
 exports[`loader domModule rewrites multiple css link tags 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><style>\\" + require(\\"./test1.css\\") + \\"</style><style>\\" + require(\\"./test2.css\\") + \\"</style></template></dom-module>\\");
 "
@@ -146,7 +146,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><template><s
 
 exports[`loader domModule transforms dom-modules 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
 "
@@ -154,7 +154,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div><
 
 exports[`loader domModule transforms multiple dom-modules 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
 
@@ -166,7 +166,7 @@ exports[`loader full components external stylesheets 1`] = `
 "
 require('../bower_components/polymer/polymer-element.html');
 
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"my-element\\\\\\">\\\\n        \\\\n        <template><style>\\" + require(\\"./outside.css\\") + \\"</style>\\\\n          <style>\\" + require(\\"./inside.css\\") + \\"</style>\\\\n          <h1>Hello, World! It's [[today]].</h1>\\\\n        </template>\\\\n        \\\\n      </dom-module>\\");
 
@@ -195,7 +195,7 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"my-element\\\\\\">\\\\n  
 
 exports[`loader html-loader html is minimized when option is set 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<script src=http://example.com/test.js></script>\\");
 "
@@ -203,7 +203,7 @@ RegisterHtmlTemplate.toBody(\\"<script src=http://example.com/test.js></script>\
 
 exports[`loader html-loader image sources are replaced with require calls 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<img src=\\\\\\"\\" + require(\\"./foo.jpg\\") + \\"\\\\\\">\\");
 "
@@ -227,7 +227,7 @@ require('./foofoo.html');
 
 exports[`loader links ignores import links with external href 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<link rel=\\\\\\"import\\\\\\" href=\\\\\\"https://example.com/foo.html\\\\\\">\\");
 "
@@ -237,7 +237,7 @@ exports[`loader links ignores links with invalid href 1`] = `""`;
 
 exports[`loader links ignores stylesheet links with external href 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"https://example.com/foo.html\\\\\\">\\");
 "
@@ -251,7 +251,7 @@ require('./foo.html');
 
 exports[`loader scripts maintains external scripts 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<script src=\\\\\\"http://example.com/test.js\\\\\\"></script>\\");
 "
@@ -276,7 +276,7 @@ require('./foo.js');
 
 exports[`loader styles font url() are properly formatted 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<style>\\\\n        @font-face {\\\\n          font-family: 'MyWebFont';\\\\n          src: url('\\" + require(\\"./webfont.eot\\") + \\"'); /* IE9 Compat Modes */\\\\n          src: url('\\" + require(\\"./webfont.eot\\") + \\"?#iefix') format('embedded-opentype'), \\\\n              url('\\" + require(\\"./webfont.woff2\\") + \\"') format('woff2'), \\\\n              url('\\" + require(\\"./webfont.woff\\") + \\"') format('woff'), \\\\n              url('\\" + require(\\"./webfont.ttf\\") + \\"')  format('truetype'), \\\\n              url('\\" + require(\\"./webfont.svg\\") + \\"#svgFontName') format('svg'); /* Legacy iOS */\\\\n        }\\\\n      </style>\\");
 "
@@ -284,7 +284,7 @@ RegisterHtmlTemplate.toBody(\\"<style>\\\\n        @font-face {\\\\n          fo
 
 exports[`loader styles in body have url() calls replaced with require statements 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<style>* {background-image: url('\\" + require(\\"./foo.jpg\\") + \\"');}</style>\\");
 "
@@ -292,7 +292,7 @@ RegisterHtmlTemplate.toBody(\\"<style>* {background-image: url('\\" + require(\\
 
 exports[`loader styles in templates have url() calls replaced with require statements 1`] = `
 "
-const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+const RegisterHtmlTemplate = require(\\"<PROJECT_ROOT>/register-html-template.js\\");
 
 RegisterHtmlTemplate.toBody(\\"<template><style>* {background-image: url('\\" + require(\\"./foo.jpg\\") + \\"');}</style></template>\\");
 "

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,6 +2993,10 @@ jest-runtime@^20.0.4:
     strip-bom "3.0.0"
     yargs "^7.0.2"
 
+jest-serializer-path@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/jest-serializer-path/-/jest-serializer-path-0.1.3.tgz#022bd32dc2a47c4cf7905dad5e2bf6bc85e4d125"
+
 jest-snapshot@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-20.0.3.tgz#5b847e1adb1a4d90852a7f9f125086e187c76566"


### PR DESCRIPTION
This PR fixes an issue with importing files from outside the project root.

### Example

Consider a directory structure like this:

```text
/path/to/projects/
├─ my-app/
│  ├─ app-element.html
│  ├─ package.json
│  └─ webpack.config.js
└─ shared/
   └─ shared-element.html
```

Suppose that `package.json` has polymer-webpack-loader in its `devDependencies` and `webpack.config.js` is configured accordingly. Suppose also that `index.html` and `shared-element.html` look like this:

#### `index.html`
```html
<link rel="import" href="../shared/shared-element.html">
```

#### `shared-element.html`
```html
<dom-module id="shared-element">
  ...
</dom-module>
```

When polymer-webpack-loader runs, it will dutifully transform `shared-element.html` into this:

```js
const RegisterHtmlTemplate = require("polymer-webpack-loader/register-html-template");

RegisterHtmlTemplate.register("<dom-module id=\"shared-element\">\n  ...\n</dom-module>");
```

Now, when webpack tries to compile this, it will look for `polymer-webpack-loader/register-html-template` in `/path/to/projects/shared` instead of `/path/to/projects/my-app`, and it will throw the following error:

```text
ERROR in ../shared/shared-element.html
Module not found: Error: Can't resolve 'polymer-webpack-loader/register-html-template' in '/path/to/projects/my-app'
 @ ../shared/shared-element.html 2:29-85
 @ ./app-element.html
```

### Workaround

Currently projects can work around this issue by adding the absolute path to polymer-webpack-loader in their webpack config's [`resolve.alias`]:

```js
resolve: {
  alias: {
    'polymer-webpack-loader': path.resolve(__dirname, 'node_modules/polymer-webpack-loader'),
  },
},
```

[`resolve.alias`]: https://webpack.js.org/configuration/resolve/#resolve-alias

### Fix

This PR fixes the problem by changing this:

```js
const RegisterHtmlTemplate = require("polymer-webpack-loader/register-html-template");
```

...to this:

```js
const RegisterHtmlTemplate = require("/path/to/projects/my-app/node_modules/polymer-webpack-loader/register-html-template");
```

### Et cetera

In order to deal with absolute paths in Jest snapshots, this PR adds [jest-serializer-path], which replaces absolute paths with `<PROJECT_ROOT>`.

[jest-serializer-path]: https://github.com/tribou/jest-serializer-path
