### PR TITLE
Remove the leading `~` from paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-webpack-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "WebPack Loader for Polymer Web Components",
   "main": "dist/cjs.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,7 @@ class ProcessHtml {
    * Process an array of ```<style>``` elements
    * If the content contains a ```url()``` statement, it is initially replaced
    * with a unique identifier used to match back the postcss processed content.
-   * 
+   *
    * A custom postcss parser plugin replaces all url hrefs with a different
    * unique placeholder. These placeholders are replaced after all processing and
    * minification with ```require``` statements
@@ -397,7 +397,7 @@ class ProcessHtml {
    * Process an array of ```<link rel="stylesheet">``` elements
    * These elements will be replaced with ```<style>``` tags
    * with ```@import url(href)```.
-   * 
+   *
    * The existing style processing will update the url to a placeholder
    * which will be replaced with a ```require``` call.
    *
@@ -466,8 +466,8 @@ class ProcessHtml {
   /**
    * Given an HTML Element, run the serialized content through the html-loader
    * to add require statements for images.
-   * 
-   * @param {HTMLElement} content 
+   *
+   * @param {HTMLElement} content
    * @param {Object} options
    * @return {string}
    */
@@ -497,8 +497,8 @@ class ProcessHtml {
    * postcss parser plugin to update url()s
    * Url records are added to the parserOptions argument which
    * is passed in.
-   * 
-   * @param {Object} cssOptions 
+   *
+   * @param {Object} cssOptions
    */
   static postcssPlugin(parserOptions) {
     return (css) => {
@@ -568,8 +568,12 @@ class ProcessHtml {
    * @return {string} adjusted path
    */
   static adjustPathIfNeeded(path) {
-    const needsAdjusted = /^(?!~|\.{0,2}\/)/.test(path);
-    return needsAdjusted ? `./${path}` : path;
+    if (/^~/.test(path)) {
+      return path.substr(1);
+    } else if (/^\.{0,2}\//.test(path)) {
+      return path;
+    }
+    return `./${path}`;
   }
 }
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -243,6 +243,12 @@ RegisterHtmlTemplate.toBody(\\"<link rel=\\\\\\"stylesheet\\\\\\" href=\\\\\\"ht
 "
 `;
 
+exports[`loader links remove leading ~ 1`] = `
+"
+require('foo/foo.html');
+"
+`;
+
 exports[`loader links transforms links 1`] = `
 "
 require('./foo.html');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -141,6 +141,16 @@ describe('loader', () => {
       loader.call(opts, '<link rel="import" href="foo.html">' +
         '<link rel="import" href="foofoo.html">');
     });
+
+    test('remove leading ~', (done) => {
+      opts.async = () => (err, source, map) => {
+        expect(err).toBe(null);
+        expect(normalisePaths(source)).toMatchSnapshot();
+        expect(map).toBe(undefined);
+        done();
+      };
+      loader.call(opts, '<link rel="import" href="~foo/foo.html">');
+    });
   });
 
   describe('domModule', () => {


### PR DESCRIPTION
When a link tag or script source path is encountered, remove any leading `~` characters and use the remaining path. This indicates that the path should be looked up using resolve and should not be relative or absolute.