### PR TITLE
Set module's assetpath attribute to fix component's importPath()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ class ProcessHtml {
           .replace(STYLE_URL_IMPORT_EXPR, replaceImportUrls)
           .replace(STYLE_URL_EXPR, replaceStyleUrls));
 
-      const assetPath = `${path.relative(path.resolve('./src'), path.dirname(this.currentFilePath)).replace(new RegExp(`\\${path.sep}`, 'g'), '/')}/`;
+      const assetPath = `${path.relative(path.resolve(this.options.componentsDirectory || './src'), path.dirname(this.currentFilePath)).replace(new RegExp(`\\${path.sep}`, 'g'), '/')}/`;
       const assetPathAttribute = assetPath.length > 1 ? ` assetpath=${assetPath} ` : '';
       const domModuleContent = domModuleArray.map(node =>
         ProcessHtml.htmlLoader(node, htmlLoaderOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import url from 'url';
+import path from 'path';
 import {
   append,
   constructors,
@@ -204,10 +205,13 @@ class ProcessHtml {
           .replace(STYLE_URL_IMPORT_EXPR, replaceImportUrls)
           .replace(STYLE_URL_EXPR, replaceStyleUrls));
 
+      const assetPath = `${path.relative(path.resolve('./src'), path.dirname(this.currentFilePath)).replace(new RegExp(`\\${path.sep}`, 'g'), '/')}/`;
+      const assetPathAttribute = assetPath.length > 1 ? ` assetpath=${assetPath} ` : '';
       const domModuleContent = domModuleArray.map(node =>
         ProcessHtml.htmlLoader(node, htmlLoaderOptions)
           .replace(STYLE_URL_IMPORT_EXPR, replaceImportUrls)
-          .replace(STYLE_URL_EXPR, replaceStyleUrls));
+          .replace(STYLE_URL_EXPR, replaceStyleUrls)
+          .replace('<dom-module', `<dom-module${assetPathAttribute}`));
 
       source += ProcessHtml.buildRuntimeSource(toBodyContent, RuntimeRegistrationType.BODY);
       source += ProcessHtml.buildRuntimeSource(domModuleContent, RuntimeRegistrationType.DOM_MODULE);

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -152,6 +152,14 @@ RegisterHtmlTemplate.register(\\"<dom-module id=\\\\\\"x-foo\\\\\\"><div></div><
 "
 `;
 
+exports[`loader domModule transforms dom-modules with assetpath 1`] = `
+"
+const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');
+
+RegisterHtmlTemplate.register(\\"<dom-module assetpath=bower_components/x-foo/  id=\\\\\\"x-foo\\\\\\"><div></div></dom-module>\\");
+"
+`;
+
 exports[`loader domModule transforms multiple dom-modules 1`] = `
 "
 const RegisterHtmlTemplate = require('polymer-webpack-loader/register-html-template');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -177,6 +177,18 @@ describe('loader', () => {
         '<div></div></dom-module>');
     });
 
+    test('transforms dom-modules with assetpath', (done) => {
+      opts.resourcePath = 'src/bower_components/x-foo/x-foo.html';
+      opts.async = () => (err, source, map) => {
+        expect(err).toBe(null);
+        expect(normalisePaths(source)).toMatchSnapshot();
+        expect(map).toBe(undefined);
+        done();
+      };
+      loader.call(opts, '<dom-module id="x-foo">' +
+          '<div></div></dom-module>');
+    });
+
     test('ignore non root level dom-modules', (done) => {
       opts.async = () => (err, source, map) => {
         expect(err).toBe(null);


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
When component is loaded by polymer-webpack-loader it lose information about original path. Polymer provide importPatch property(https://www.polymer-project.org/2.0/docs/devguide/dom-template#urls-in-templates). But to work it correctly with webpack loader assetpath attribute should be set on module.